### PR TITLE
feat: add markdown table update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,58 @@ After the run the JSON file should contain results for all test specs that ran l
 }
 ```
 
+## Options
+
+### filename
+
+By default, this plugin saves the JSON result into "results.json" file. You can change the output filename using the `filename` option
+
+```js
+// https://github.com/bahmutov/cypress-json-results
+require('cypress-json-results')({
+  on,
+  filename: 'output.json',
+})
+```
+
+Note: the plugin assumes the output folder already exists
+
+### updateMarkdownFile
+
+You can automatically update a Markdown table inside the given file with the test counts. See the section below [Cypress test counts](#cypress-test-counts) for an example. The table should be surrounded with HTML comments
+
+```
+<!-- cypress-test-counts -->
+The table contents
+<!-- cypress-test-counts-end -->
+```
+
+Tip: prevent the Prettier from messing with the formatting by surrounding the table with ignore comments, see [How to configure Prettier and VSCode](https://glebbahmutov.com/blog/configure-prettier-in-vscode/).
+
+```
+<!-- prettier-ignore-start -->
+<!-- cypress-test-counts -->
+  ... table text ...
+<!-- cypress-test-counts-end -->
+<!-- prettier-ignore-end -->
+```
+
+## Cypress test counts
+
+This repo has the following test numbers
+
+<!-- prettier-ignore-start -->
+<!-- cypress-test-counts -->
+Test status | Count
+---|---
+Passed | 3
+Failed | 0
+Pending | 1
+Skipped | 0
+**Total** | 4
+<!-- cypress-test-counts-end -->
+<!-- prettier-ignore-end -->
+
 ## Small print
 
 Author: Gleb Bahmutov &lt;gleb.bahmutov@gmail.com&gt; &copy; 2022

--- a/cypress/integration/utils-spec.js
+++ b/cypress/integration/utils-spec.js
@@ -1,0 +1,71 @@
+/// <reference types="cypress" />
+
+import { getCountTable, updateText } from '../../src/update-text'
+import { stripIndent } from 'common-tags'
+
+describe('Markdown utils', () => {
+  it('forms table', () => {
+    const totals = {
+      passed: 10,
+      failed: 2,
+      pending: 1,
+      skipped: 3,
+      tests: 15,
+    }
+    const text = getCountTable(totals)
+    expect(text).to.equal(stripIndent`
+      Test status | Count
+      ---|---
+      Passed | 10
+      Failed | 2
+      Pending | 1
+      Skipped | 3
+      **Total** | 15
+    `)
+  })
+
+  it('updates table in the text', () => {
+    const text = stripIndent`
+      This is some Markdown text
+      and then there is a comment with the table
+
+      <!-- cypress-test-counts -->
+      Test status | Count
+      ---|---
+      Passed | 1
+      Failed | 0
+      Pending | 1
+      Skipped | 0
+      **Total** | 2
+      <!-- cypress-test-counts-end -->
+
+      the end
+    `
+
+    const totals = {
+      passed: 10,
+      failed: 2,
+      pending: 1,
+      skipped: 3,
+      tests: 15,
+    }
+
+    const updated = updateText(text, totals)
+    expect(updated).to.equal(stripIndent`
+      This is some Markdown text
+      and then there is a comment with the table
+
+      <!-- cypress-test-counts -->
+      Test status | Count
+      ---|---
+      Passed | 10
+      Failed | 2
+      Pending | 1
+      Skipped | 3
+      **Total** | 15
+      <!-- cypress-test-counts-end -->
+
+      the end
+    `)
+  })
+})

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,5 +12,6 @@ module.exports = (on, config) => {
   require('../../src')({
     on,
     filename: 'results.json',
+    updateMarkdownFile: 'README.md',
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -870,8 +870,7 @@
     "common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
-      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
-      "dev": true
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="
     },
     "compare-func": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/bahmutov/cypress-json-results.git"
+  },
+  "dependencies": {
+    "common-tags": "^1.8.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 const fs = require('fs')
+const { updateText } = require('./update-text')
 
 function registerCypressJsonResults(options = {}) {
   const defaults = {
@@ -45,6 +46,17 @@ function registerCypressJsonResults(options = {}) {
     const str = JSON.stringify(allResults, null, 2)
     fs.writeFileSync(options.filename, str + '\n')
     console.log('cypress-json-results: wrote results to %s', options.filename)
+
+    if (options.updateMarkdownFile) {
+      const markdownFile = options.updateMarkdownFile
+      const markdown = fs.readFileSync(markdownFile, 'utf8')
+      const updated = updateText(markdown, allResults.totals)
+      fs.writeFileSync(markdownFile, updated)
+      console.log(
+        'cypress-json-results: updated Markdown file %s',
+        markdownFile,
+      )
+    }
   })
 }
 

--- a/src/update-text.js
+++ b/src/update-text.js
@@ -1,0 +1,38 @@
+const { stripIndent } = require('common-tags')
+
+const START = '<!-- cypress-test-counts -->'
+const END = '<!-- cypress-test-counts-end -->'
+
+function getCountTable(totals) {
+  return stripIndent`
+    Test status | Count
+    ---|---
+    Passed | ${totals.passed}
+    Failed | ${totals.failed}
+    Pending | ${totals.pending}
+    Skipped | ${totals.skipped}
+    **Total** | ${totals.tests}
+  `
+}
+
+function updateText(text, totals) {
+  const startIndex = text.indexOf(START)
+  if (startIndex === -1) {
+    throw new Error('Could not find cypress-test-counts comment')
+  }
+
+  const endIndex = text.indexOf(END)
+  if (endIndex === -1) {
+    throw new Error('Could not find cypress-test-counts-end comment')
+  }
+
+  const start = text.slice(0, startIndex)
+  const end = text.slice(endIndex)
+  const updatedTable = getCountTable(totals)
+  return start + START + '\n' + updatedTable + '\n' + end
+}
+
+module.exports = {
+  updateText,
+  getCountTable,
+}


### PR DESCRIPTION
### updateMarkdownFile

You can automatically update a Markdown table inside the given file with the test counts. See the section below [Cypress test counts](#cypress-test-counts) for an example. The table should be surrounded with HTML comments

```
<!-- cypress-test-counts -->
The table contents
<!-- cypress-test-counts-end -->
```